### PR TITLE
adding check if flase with and without cross

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -369,10 +369,10 @@ hard_checks_status <- function(validator, hard_check){
   error_counter <- 0
   warning_counter <- 0
   for (entry in validator$log) {
-    if (entry$entry_type == "error" && entry$outcome == "\U000274C fail") {
+    if (entry$entry_type == "error" && (entry$outcome == "\U000274C fail" || entry$outcome == "fail")) {
       error_counter <- error_counter + 1
     }
-    else if (entry$entry_type == "warning" && entry$outcome == "\U000274C fail") {
+    else if (entry$entry_type == "warning" && (entry$outcome == "\U000274C fail" || entry$outcome == "fail")) {
       warning_counter <- warning_counter + 1
     }
   }


### PR DESCRIPTION
Think this should fix failing workflows. 
I guess its something to do with the outcome is labled as "fail" not "\U000274C fail" when running in workflows. Added an or statement to check for both options for fail in hard checks