### PR TITLE
684 rework new validator

### DIFF
--- a/R/validator.R
+++ b/R/validator.R
@@ -101,14 +101,6 @@ assign_agent_typechecks <- function(agent,schema){
     }
   }
 
-  agent <- agent |>
-    pointblank::col_is_integer(columns = eval(int_columns)) |>
-    pointblank::col_is_date(columns = eval(date_columns)) |>
-    pointblank::col_is_logical(columns = eval(logical_columns)) |>
-    pointblank::col_is_numeric(columns = eval(numeric_columns)) |>
-    pointblank::col_is_factor(columns = eval(factor_columns)) |>
-    pointblank::col_is_character(columns = eval(char_columns))
-
   return(agent)
 }
 

--- a/R/validator.R
+++ b/R/validator.R
@@ -106,6 +106,7 @@ create_pointblank_agent <- function(data, schema){
     pointblank::col_is_date(columns = eval(date_columns)) |>
     pointblank::col_is_logical(columns = eval(logical_columns)) |>
     pointblank::col_is_numeric(columns = eval(numeric_columns)) |>
+    pointblank::col_is_factor(columns = eval(factor_columns)) |>
     pointblank::col_is_character(columns = eval(char_columns))
 
   return(agent)

--- a/R/validator.R
+++ b/R/validator.R
@@ -104,7 +104,7 @@ create_pointblank_agent <- function(data, schema){
       factor_columns <- c(factor_columns, col)
     } else if (col_info$type == "double") {
       numeric_columns <- c(numeric_columns, col)
-    } else if (col_info$type == "Date") {
+    } else if (col_info$type == "date") {
       date_columns <- c(date_columns, col)
     } else if (col_info$type == "logical") {
       logical_columns <- c(logical_columns, col)

--- a/R/validator.R
+++ b/R/validator.R
@@ -71,10 +71,46 @@ new_validator <- function(data, schema) {
     entry_type = "info"
   )
 
-  agent <- pointblank::create_agent(tbl = data)
+  validator$agent <- create_pointblank_agent(validator$data, validator$schema)
 
   return(validator)
 }
+
+create_pointblank_agent <- function(data, schema){
+  agent <- pointblank::create_agent(tbl = data)
+  int_columns <- c()
+  factor_columns <- c()
+  numeric_columns <- c()
+  date_columns <- c()
+  logical_columns <- c()
+  char_columns <- c()
+  for (col in names(schema$columns)) {
+    col_info <- schema$columns[[col]]
+    if (col_info$type == "integer") {
+      int_columns <- c(int_columns, col)
+    } else if (col_info$type == "factor") {
+      factor_columns <- c(factor_columns, col)
+    } else if (col_info$type == "double") {
+      numeric_columns <- c(numeric_columns, col)
+    } else if (col_info$type == "Date") {
+      date_columns <- c(date_columns, col)
+    } else if (col_info$type == "logical") {
+      logical_columns <- c(logical_columns, col)
+    } else if (col_info$type == "character") {
+      char_columns <- c(char_columns, col)
+    }
+  }
+
+  agent <- agent |>
+    pointblank::col_is_integer(columns = eval(int_columns)) |>
+    pointblank::col_is_date(columns = eval(date_columns)) |>
+    pointblank::col_is_logical(columns = eval(logical_columns)) |>
+    pointblank::col_is_numeric(columns = eval(numeric_columns)) |>
+    pointblank::col_is_character(columns = eval(char_columns))
+
+  return(agent)
+}
+
 
 #' Validate a Validator Object
 #'

--- a/R/validator.R
+++ b/R/validator.R
@@ -71,25 +71,13 @@ new_validator <- function(data, schema) {
     entry_type = "info"
   )
 
-  validator$agent <- create_pointblank_agent(validator$data, validator$schema)
+  validator$agent <- pointblank::create_agent(tbl = validator$data)
 
   return(validator)
 }
 
 
-#' create_pointblank_agent
-#'
-#' creates pointblank agent with validation steps based on schema column types. Can be
-#' appended for boilerplate checks.
-#'
-#' @param data A data frame to validate against the schema.
-#' @param schema A schema object that defines the validation rules, including column types.
-#'
-#' @return A pointblank agent object with validation steps based on the schema.
-#'
-#' @export
-create_pointblank_agent <- function(data, schema){
-  agent <- pointblank::create_agent(tbl = data)
+assign_agent_typechecks <- function(agent,schema){
   int_columns <- c()
   factor_columns <- c()
   numeric_columns <- c()

--- a/R/validator.R
+++ b/R/validator.R
@@ -76,6 +76,18 @@ new_validator <- function(data, schema) {
   return(validator)
 }
 
+
+#' create_pointblank_agent
+#'
+#' creates pointblank agent with validation steps based on schema column types. Can be
+#' appended for boilerplate checks.
+#'
+#' @param data A data frame to validate against the schema.
+#' @param schema A schema object that defines the validation rules, including column types.
+#'
+#' @return A pointblank agent object with validation steps based on the schema.
+#'
+#' @export
 create_pointblank_agent <- function(data, schema){
   agent <- pointblank::create_agent(tbl = data)
   int_columns <- c()

--- a/tests/test-new_validator_agent,R
+++ b/tests/test-new_validator_agent,R
@@ -1,0 +1,23 @@
+df <- data.frame(a = 1.23, b = 2, c = 3)
+columns <- list(
+  a = list(type = "double", optional = TRUE, max_val = 100, min_val = 0, max_decimal = 2, min_decimal = 0),
+  b = list(type = "character", optional = TRUE, min_string_length = 0, max_string_length = 10)
+)
+schema <- list(
+  check_duplicates = FALSE,
+  check_completeness = FALSE,
+  columns = columns)
+
+
+test_that("new validator has agent field", {
+    validator <- new_validator(
+    data = df,
+    schema = list(
+      columns = columns,
+      check_completeness = FALSE,
+      check_duplicates = FALSE
+    )
+  ) 
+  expect_true("agent" %in% names(validator))
+  expect_true(inherits(validator$agent, "ptblank_agent"))
+})


### PR DESCRIPTION
Changes to create pointblank agent when creating a new_validator object. 
Unit tests have been updated to check this is correctly created.
validator$agent can be expanded when calling check functions using pipe operator